### PR TITLE
Make the use of SAML in development env fully configurable.

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-module OmniAuth
-  module Strategies
-    # tell OmniAuth to load our strategy
-    autoload :Imipre, Rails.root.join('lib', 'imipre_strategy')
-  end
-end
-
 if Rails.application.secrets.dig(:omniauth, :imipre, :enabled)
+  module OmniAuth
+    module Strategies
+      # tell OmniAuth to load our strategy
+      autoload :Imipre, Rails.root.join('lib', 'imipre_strategy')
+    end
+  end
+
   Devise.setup do |config|
     config.omniauth :imipre, scope: Chamber.env.imipre.scope, domain: Chamber.env.imipre.domain
   end
@@ -15,6 +15,7 @@ if Rails.application.secrets.dig(:omniauth, :imipre, :enabled)
   Decidim::User.omniauth_providers << :imipre
 end
 
+Rails.logger.info "SAML ENABLED? #{Rails.application.secrets.dig(:omniauth, :saml, :enabled)}"
 if Rails.application.secrets.dig(:omniauth, :saml, :enabled)
   Devise.setup do |config|
     config.omniauth :saml,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,10 @@ Rails.application.routes.draw do
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 
-  get '/users/sign_in', to: redirect { |path_params, req| "/users/auth/saml?#{req.params.to_query}" }, as: :new_user_session
-  get '/users/sign_up', to: redirect { |path_params, req| "/users/auth/saml?#{req.params.to_query}" }, as: :new_user_registration
+  if Rails.application.secrets.dig(:omniauth, :saml, :enabled)
+    get '/users/sign_in', to: redirect { |path_params, req| "/users/auth/saml?#{req.params.to_query}" }, as: :new_user_session
+    get '/users/sign_up', to: redirect { |path_params, req| "/users/auth/saml?#{req.params.to_query}" }, as: :new_user_registration
+  end
 
   mount Decidim::Core::Engine => '/'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -51,7 +51,7 @@ development:
       client_secret: <%= Chamber.env.imipre.client_secret %>
       icon_path: Oauth_logo.svg
     saml:
-      enabled: true
+      enabled: false
       idp_cert_fingerprint: <%= Chamber.env.saml.idp_cert_fingerprint %>
       idp_sso_target_url: <%= Chamber.env.saml.idp_sso_target_url %>
 


### PR DESCRIPTION
In order to be able to sign in into the admin panel without the need of configuring SAML (which is inside the city council vpn) for the development env, this PR makes it fully configurable.